### PR TITLE
fix: dev: ImportError on python2

### DIFF
--- a/google_images_download/__main__.py
+++ b/google_images_download/__main__.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
 
-
-def main():
-    import google_images_download.google_images_download
+from .__init__ import main
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
simple fix for `ImportError` on python2

this also enable module to be run directly. e.g. `python -m google_images_download -k 'red picture`

related #41