### PR TITLE
Fixed bug where files are left open

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -536,7 +536,10 @@ class googleimagesdownload:
                     timeout = float(socket_timeout)
                 else:
                     timeout = 10
+
                 response = urlopen(req, None, timeout)
+                data = response.read()
+                response.close()
 
                 # keep everything after the last '/'
                 image_name = str(image_url[(image_url.rfind('/')) + 1:])
@@ -557,8 +560,6 @@ class googleimagesdownload:
                     prefix = ''
 
                 path = main_directory + "/" + dir_name + "/" + prefix + str(count) + ". " + image_name
-                data = response.read()
-                response.close()
 
                 try:
                     output_file = open(path, 'wb')
@@ -575,10 +576,9 @@ class googleimagesdownload:
                     output_file.close()
 
                 #return image name back to calling method to use it for thumbnail downloads
-                return_image_name = prefix + str(count) + ". " + image_name
-
                 download_status = 'success'
-                download_message = "Completed Image ====> " + prefix +  str(count) + ". " + image_name
+                download_message = "Completed Image ====> " + prefix + str(count) + ". " + image_name
+                return_image_name = prefix + str(count) + ". " + image_name
 
                 # image size parameter
                 if print_size:
@@ -608,6 +608,7 @@ class googleimagesdownload:
             download_status = 'fail'
             download_message = "IOError on an image...trying next one..." + " Error: " + str(e)
             return_image_name = ''
+
         return download_status,download_message,return_image_name
 
 

--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -259,7 +259,11 @@ class googleimagesdownload:
             pass
         req = Request(url, headers={
             "User-Agent": "Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.27 Safari/537.17"})
+
         response = urlopen(req, None, 10)
+        data = response.read()
+        response.close()
+
         image_name = str(url[(url.rfind('/')) + 1:])
         if '?' in image_name:
             image_name = image_name[:image_name.find('?')]
@@ -268,9 +272,6 @@ class googleimagesdownload:
         else:
             file_name = main_directory + "/" + image_name + ".jpg"
             image_name = image_name + ".jpg"
-
-        data = response.read()
-        response.close()
 
         try:
             output_file = open(file_name, 'wb')

--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -264,14 +264,24 @@ class googleimagesdownload:
         if '?' in image_name:
             image_name = image_name[:image_name.find('?')]
         if ".jpg" in image_name or ".gif" in image_name or ".png" in image_name or ".bmp" in image_name or ".svg" in image_name or ".webp" in image_name or ".ico" in image_name:
-            output_file = open(main_directory + "/" + image_name, 'wb')
+            file_name = main_directory + "/" + image_name
         else:
-            output_file = open(main_directory + "/" + image_name + ".jpg", 'wb')
+            file_name = main_directory + "/" + image_name + ".jpg"
             image_name = image_name + ".jpg"
 
         data = response.read()
-        output_file.write(data)
         response.close()
+
+        try:
+            output_file = open(file_name, 'wb')
+            output_file.write(data)
+        except OSError as e:
+            raise e
+        except IOError as e:
+            raise e
+        finally:
+            output_file.close()
+
         print("completed ====> " + image_name)
         return
 
@@ -465,13 +475,24 @@ class googleimagesdownload:
                     timeout = float(socket_timeout)
                 else:
                     timeout = 10
+
                 response = urlopen(req, None, timeout)
+                data = response.read()
+                response.close()
 
                 path = main_directory + "/" + dir_name + " - thumbnail" + "/" + return_image_name
-                output_file = open(path, 'wb')
-                data = response.read()
-                output_file.write(data)
-                response.close()
+
+                try:
+                    output_file = open(path, 'wb')
+                    output_file.write(data)
+                except OSError as e:
+                    download_status = 'fail'
+                    download_message = "OSError on an image...trying next one..." + " Error: " + str(e)
+                except IOError as e:
+                    download_status = 'fail'
+                    download_message = "IOError on an image...trying next one..." + " Error: " + str(e)
+                finally:
+                    output_file.close()
 
                 download_status = 'success'
                 download_message = "Completed Image Thumbnail ====> " + return_image_name
@@ -536,10 +557,22 @@ class googleimagesdownload:
                     prefix = ''
 
                 path = main_directory + "/" + dir_name + "/" + prefix + str(count) + ". " + image_name
-                output_file = open(path, 'wb')
                 data = response.read()
-                output_file.write(data)
                 response.close()
+
+                try:
+                    output_file = open(path, 'wb')
+                    output_file.write(data)
+                except OSError as e:
+                    download_status = 'fail'
+                    download_message = "OSError on an image...trying next one..." + " Error: " + str(e)
+                    return_image_name = ''
+                except IOError as e:
+                    download_status = 'fail'
+                    download_message = "IOError on an image...trying next one..." + " Error: " + str(e)
+                    return_image_name = ''
+                finally:
+                    output_file.close()
 
                 #return image name back to calling method to use it for thumbnail downloads
                 return_image_name = prefix + str(count) + ". " + image_name


### PR DESCRIPTION
After downloading images and writing them to disk, the files are left open. I opened an issue about this, but here's the fix. I also moved some things around so web responses aren't open for as long (and it will be easier for error handling).