### PR TITLE
Print out exception message when attempting to find the Chrome driver

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -151,10 +151,10 @@ class googleimagesdownload:
 
         try:
             browser = webdriver.Chrome(chromedriver, chrome_options=options)
-        except:
+        except Exception as e:
             print("Looks like we cannot locate the path the 'chromedriver' (use the '--chromedriver' "
                   "argument to specify the path to the executable.) or google chrome browser is not "
-                  "installed on your machine")
+                  "installed on your machine (exception: %s)" % e)
             sys.exit()
         browser.set_window_size(1024, 768)
 


### PR DESCRIPTION
I'm finding it hard to know why my chromium / selenium setup is not working so as a first step I thought I'd get the tool to print out the error. 