### PR TITLE
For --extract_metadata, skip failed downloads and include saved filename

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -703,8 +703,6 @@ class googleimagesdownload:
                 if arguments['metadata']:
                     print("\nImage Metadata: " + str(object))
 
-                items.append(object)  # Append all the links in the list named 'Links'
-
                 #download the images
                 download_status,download_message,return_image_name,absolute_path = self.download_image(object['image_link'],object['image_format'],main_directory,dir_name,count,arguments['print_urls'],arguments['socket_timeout'],arguments['prefix'],arguments['print_size'],arguments['no_numbering'])
                 print(download_message)
@@ -716,6 +714,7 @@ class googleimagesdownload:
                         print(download_message_thumbnail)
 
                     count += 1
+                    items.append(object)  # Append all the links in the list named 'Links'
                     abs_path.append(absolute_path)
                 else:
                     errorCount += 1

--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -714,6 +714,7 @@ class googleimagesdownload:
                         print(download_message_thumbnail)
 
                     count += 1
+                    object['image_filename'] = return_image_name
                     items.append(object)  # Append all the links in the list named 'Links'
                     abs_path.append(absolute_path)
                 else:


### PR DESCRIPTION
The metadata file generated via the `--extract_metadata` flag needs improvement. Currently, it's difficult (in certain cases, impossible) to match _metadata entries_ (within the metadata output file) to _downloaded image files_.

This pull request makes two changes:

**1. If a image request fails, don't include that in the `--extract_metadata` output file.**

We ensure there's a one-to-one mapping between a metadata entry and its correspoding saved image file. Not doing this may introduce an ambiguous edge case. For example, imagine two successive image links with the same filename in the url path and one of the two download request tasks fails— in this scenario, it is not possible to determine which image link was downloaded successfully (e.g., does `2. apple.jpg` match with `http://example.com/1/apple.jpg` or `http://example.com/2/apple.jpg`?).

**2. For each metadata record, include the filename for the saved image file.**

We include the saved filename along with each metadata record. This way, you don't need to write complicated logic to determine which entry matches to which saved image filename. Otherwise, one would have to determine the image filename by duplicating the image filename derivation logic (i.e., `filename.jpg` to `12. filename.jpg`). Should `google-images-download`'s image filename derivation logic ever change, external scripts that duplicate that logic will also fail.

Hope these changes will make this tool more robust and the `--extract_metadata` feature more useful.

Thanks for reviewing this pull request.