### PR TITLE
Fix decoding response data

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -137,7 +137,7 @@ class googleimagesdownload:
                 headers['User-Agent'] = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
                 req = urllib.request.Request(url, headers=headers)
                 resp = urllib.request.urlopen(req)
-                respData = str(resp.read())
+                respData = resp.read().decode()
                 return respData
             except Exception as e:
                 print("Could not open URL. Please check your internet connection and/or ssl settings \n"
@@ -727,8 +727,7 @@ class googleimagesdownload:
             cur_version = sys.version_info
             if cur_version >= version: #python3
                 try:
-                    object_decode = bytes(object_raw, "utf-8").decode("unicode_escape")
-                    final_object = json.loads(object_decode)
+                    final_object = json.loads(object_raw)
                 except:
                     final_object = ""
             else:  #python2

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,33 @@
+from google_images_download import google_images_download
+import os
+import json
+import time
+
+from .test_google_images_download import silent_remove_of_file
+
+
+def test_metadata():
+    start_time = time.time()
+    output_folder_path = os.path.join(os.path.realpath('.'), 'logs')
+
+    keywords = ["Polar bears", "ほげ"]
+    for keyword in keywords:
+        argumnets = {
+            "keywords": keyword,
+            "limit": 5,
+            "no_download": True,
+            "extract_metadata": True
+        }
+        response = google_images_download.googleimagesdownload()
+        response.download(argumnets)
+        with open(os.path.join(output_folder_path, '{}.json'.format(keyword)), 'r') as fp:
+            for item in json.load(fp):
+                assert keyword.lower() in item['image_description'].lower()
+
+    files_modified_after_test_started = [name for name in os.listdir(output_folder_path) if os.path.isfile(os.path.join(output_folder_path, name)) and os.path.getmtime(os.path.join(output_folder_path, name)) > start_time]
+    print(f"Cleaning up all files downloaded by test {__name__}...")
+    for file in files_modified_after_test_started:
+        if silent_remove_of_file(os.path.join(output_folder_path, file)):
+            print(f"Deleted {os.path.join(output_folder_path, file)}")
+        else:
+            print(f"Failed to delete {os.path.join(output_folder_path, file)}")


### PR DESCRIPTION
When searching in Japanese, there was a problem that garbled characters were generated in metadata obtained by `extract_meta`.

In `download_page` it uses `str(resp.read())` to convert bytes to a string, which is wrong, It must decode correctly.
And it can eliminate unnecessary conversion when converting to JSON.

I also added test cases.