### PR TITLE
Decoding issue when using characters like "åäö"

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -919,7 +919,7 @@ class googleimagesdownload:
                 while i < len(search_keyword):      # 3.for every main keyword
                     iteration = "\n" + "Item no.: " + str(i + 1) + " -->" + " Item name = " + (pky) + (search_keyword[i]) + (sky)
                     if not arguments["silent_mode"]:
-                        print(iteration.encode('raw_unicode_escape').decode('utf-8'))
+                        print(iteration)
                         print("Evaluating...")
                     else:
                         print("Downloading images for: " + (pky) + (search_keyword[i]) + (sky) + " ...")


### PR DESCRIPTION
"print(iteration.encode('raw_unicode_escape').decode('utf-8'))" caused the script to crash when characters like "åäö" were used, removing the encoding (or comment/remove the print function) solves this issue.