### PR TITLE
To set proper extension in image name.

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -304,8 +304,8 @@ class googleimagesdownload:
         image_name = str(url[(url.rfind('/')) + 1:])
         if '?' in image_name:
             image_name = image_name[:image_name.find('?')]
-        # if ".jpg" in image_name or ".gif" in image_name or ".png" in image_name or ".bmp" in image_name or ".svg" in image_name or ".webp" in image_name or ".ico" in image_name:
-        if any(map(lambda extension: extension in image_name, extensions)):
+        # if ".jpg" or ".gif" or ".png" or ".bmp" or ".svg" or ".webp" or ".ico" at last in image_name:
+        if any(map(lambda extension: re.search(extension + "$", image_name), extensions)):
             file_name = main_directory + "/" + image_name
         else:
             file_name = main_directory + "/" + image_name + ".jpg"


### PR DESCRIPTION
To check whether extension is at the end of the image name instead of checking anywhere in whole image name.