### PR TITLE
Fixed issue with links not being found for new google response format

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -750,7 +750,12 @@ class googleimagesdownload:
 
     # Getting all links with the help of '_images_get_next_image'
     def _get_all_items(self,page,main_directory,dir_name,limit,arguments):
-        self._parse_AF_initDataCallback(page)
+        
+        try:
+            self._parse_AF_initDataCallback(page)
+        except Exception as e:
+            print('WARNING: _parse_AF_initDataCallback failed', e)
+        
         items = []
         abs_path = []
         errorCount = 0

--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -530,7 +530,7 @@ class googleimagesdownload:
                 data = response.read()
                 response.close()
 
-                path = main_directory + "/" + dir_name + " - thumbnail" + "/" + return_image_name
+                path = remove_illegal_characters(main_directory + "/" + dir_name + " - thumbnail" + "/" + return_image_name)
 
                 try:
                     output_file = open(path, 'wb')
@@ -936,7 +936,7 @@ class googleimagesdownload:
                     paths_agg[i] = paths[i]
                 if not arguments["silent_mode"]:
                     if arguments['print_paths']:
-                        print(paths.encode('raw_unicode_escape').decode('utf-8'))
+                        print(paths)
                 return paths_agg, errors
         # for input coming from CLI
         else:
@@ -945,7 +945,7 @@ class googleimagesdownload:
                 paths_agg[i] = paths[i]
             if not arguments["silent_mode"]:
                 if arguments['print_paths']:
-                    print(paths.encode('raw_unicode_escape').decode('utf-8'))
+                    print(paths)
         return paths_agg, errors
 
     def download_executor(self,arguments):
@@ -1091,6 +1091,23 @@ class googleimagesdownload:
                     if not arguments["silent_mode"]:
                         print("\nErrors: " + str(errorCount) + "\n")
         return paths, total_errors
+
+
+def remove_illegal_characters(string):
+    string = str(string)
+
+    badchars = re.compile(r'[^A-Za-z0-9_. ]+|^\.|\.$|^ | $|^$')
+    badnames = re.compile(r'(aux|com[1-9]|con|lpt[1-9]|prn)(\.|$)')
+
+    try:
+        name = badchars.sub('_', string)
+        if badnames.match(name):
+            name = '_' + name
+        return name
+    except Exception as e:
+        print("ERROR cleaning filename:", e)
+    return string
+
 
 #------------- Main Program -------------#
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 selenium
+bs4


### PR DESCRIPTION
the new 2020 google images update changes where the image information is stored, I found that they're stored in a script in variable `AF_initDataCallback`

This implementation is backward compatible (using rg_meta), and if that doesn't work, then it will parse the new info.

This code was tested with both python3 and python2