### PR TITLE
Fix #264; sanitize thumbnail image_name and return absolut path for thumbnail_only

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -587,6 +587,28 @@ class googleimagesdownload:
 
     # Download Images
     def download_image(self,image_url,image_format,main_directory,dir_name,count,print_urls,socket_timeout,prefix,print_size,no_numbering,no_download,save_source,img_src,silent_mode,thumbnail_only,format,ignore_urls):
+        extensions = [".jpg", ".jpeg", ".gif", ".png", ".bmp", ".svg", ".webp", ".ico"]
+        # keep everything after the last '/'
+        image_name = str(image_url[(image_url.rfind('/')) + 1:])
+        if format:
+            if not image_format or image_format != format:
+                download_status = 'fail'
+                download_message = "Wrong image format returned. Skipping..."
+                return_image_name = ''
+                absolute_path = ''
+                return download_status, download_message, return_image_name, absolute_path
+
+        if image_format == "" or not image_format or "." + image_format not in extensions:
+            download_status = 'fail'
+            download_message = "Invalid or missing image format. Skipping..."
+            return_image_name = ''
+            absolute_path = ''
+            return download_status, download_message, return_image_name, absolute_path
+        elif image_name.lower().find("." + image_format) < 0:
+            image_name = image_name + "." + image_format
+        else:
+            image_name = image_name[:image_name.lower().find("." + image_format) + (len(image_format) + 1)]
+        
         if not silent_mode:
             if print_urls or no_download:
                 print("Image URL: " + image_url)
@@ -594,7 +616,8 @@ class googleimagesdownload:
             if any(url in image_url for url in ignore_urls.split(',')):
                 return "fail", "Image ignored due to 'ignore url' parameter", None, image_url
         if thumbnail_only:
-            return "success", "Skipping image download...", str(image_url[(image_url.rfind('/')) + 1:]), image_url
+            absolute_path = os.path.abspath(main_directory + "/" + dir_name + " - thumbnail" + "/" + image_name)
+            return "success", "Skipping image download...", image_name, absolute_path
         if no_download:
             return "success","Printed url without downloading",None,image_url
         try:
@@ -610,28 +633,6 @@ class googleimagesdownload:
                 response = urlopen(req, None, timeout)
                 data = response.read()
                 response.close()
-
-                extensions = [".jpg", ".jpeg", ".gif", ".png", ".bmp", ".svg", ".webp", ".ico"]
-                # keep everything after the last '/'
-                image_name = str(image_url[(image_url.rfind('/')) + 1:])
-                if format:
-                    if not image_format or image_format != format:
-                        download_status = 'fail'
-                        download_message = "Wrong image format returned. Skipping..."
-                        return_image_name = ''
-                        absolute_path = ''
-                        return download_status, download_message, return_image_name, absolute_path
-
-                if image_format == "" or not image_format or "." + image_format not in extensions:
-                    download_status = 'fail'
-                    download_message = "Invalid or missing image format. Skipping..."
-                    return_image_name = ''
-                    absolute_path = ''
-                    return download_status, download_message, return_image_name, absolute_path
-                elif image_name.lower().find("." + image_format) < 0:
-                    image_name = image_name + "." + image_format
-                else:
-                    image_name = image_name[:image_name.lower().find("." + image_format) + (len(image_format) + 1)]
 
                 # prefix name in image
                 if prefix:


### PR DESCRIPTION
Rebased version of https://github.com/hardikvasa/google-images-download/pull/265 with only the fixes for https://github.com/hardikvasa/google-images-download/issues/264 as requested.
I am quite tired right now, so you should check the code thoroughly :D 

It is really nice that you are active again in this repository. 